### PR TITLE
Forbid inline polymorphic request bodies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /dist/
 /node_modules/
+/.idea/
+/openapi-lint.iml

--- a/src/rules/named-polymorphic-request-body.ts
+++ b/src/rules/named-polymorphic-request-body.ts
@@ -1,0 +1,20 @@
+import { Rule, ValidationError, ApiSpec, getAllObjectProperties, hasProperty, getItem } from '../Rule';
+
+export default class NamedPolymorphicRequestBody implements Rule {
+    describe() {
+        return 'Polymorphic (oneOf) request bodies must be defined as named types, as opposed to being defined' +
+            'inline. The Java code generator wont be able to handle them otherwise.';
+    }
+
+    validate(json: ApiSpec) {
+        getAllObjectProperties(json, 'paths').forEach(({ path, object }) => {
+            ['post', 'put', 'patch'].forEach(verb => {
+                if (hasProperty(object, verb)) {
+                    if (getItem(object, verb + '.requestBody.content.application/json.schema.oneOf')) {
+                        throw new ValidationError(`Inline polymorphic body in '${path}' ${verb}. These must be defined as named types.`);
+                    }
+                }
+            });
+        });
+    }
+}


### PR DESCRIPTION
The Java code generator for the OpenAPI specification generates
invalid code if polymorphic request bodies (using oneOf) is
defined inline. However, it works just fine if the request body
instead is a reference to named type defining the oneOf body.

This commit adds a rule that forbids inline polymorphic request
bodies.